### PR TITLE
fixed method matchedToAnyExtension of the parser of files

### DIFF
--- a/src/files.parser.js
+++ b/src/files.parser.js
@@ -5,7 +5,7 @@ function matchedToAnyExtension(filename, filesExtentions) {
     let isMatched = false;
     filesExtentions.forEach((extention) => {
 
-        if (filename.search(extention) >= (filename.length - extention.length)) {
+        if (filename.lastIndexOf(extention) >= (filename.length - extention.length)) {
             isMatched = true;
         }
 

--- a/test/files.parser.test.js
+++ b/test/files.parser.test.js
@@ -13,7 +13,7 @@ describe('Files parser', () => {
 
         const files = findFilesInDirectory(directory, extentions);
 
-        files[1].should.equal(directory + '/react.component.view.js');
+        files[0].should.equal(directory + '/react.component.view.js');
 
     });
 


### PR DESCRIPTION
Method 'search' of the string implicitly convert it's argument to the RegExp object. So, with argument '.js' in the long file path with folder 'js', for example '/home/ivan/i18n-central-storage/test/fixtures/files/js/modules/common/models/appointment.model.js',  this method find a substring '/js', so method matchedToAnyExtension return incorrect result.